### PR TITLE
Fixed form type which do not work with sf2.1 RC

### DIFF
--- a/Form/Type/GoogleMapType.php
+++ b/Form/Type/GoogleMapType.php
@@ -52,14 +52,14 @@ class GoogleMapType extends AbstractType
     public function buildView(FormView $view, FormInterface $form, array $options)
     {
         $view
-            ->setVar('lat_name', $options['lat_name'])
-            ->setVar('lng_name', $options['lng_name'])
-            ->setVar('map_width', $options['map_width'])
-            ->setVar('map_height', $options['map_height'])
-            ->setVar('default_lat', $options['default_lat'])
-            ->setVar('default_lng', $options['default_lng'])
-            ->setVar('include_jquery', $options['include_jquery'])
-            ->setVar('include_gmaps_js', $options['include_gmaps_js'])
+            ->set('lat_name', $options['lat_name'])
+            ->set('lng_name', $options['lng_name'])
+            ->set('map_width', $options['map_width'])
+            ->set('map_height', $options['map_height'])
+            ->set('default_lat', $options['default_lat'])
+            ->set('default_lng', $options['default_lng'])
+            ->set('include_jquery', $options['include_jquery'])
+            ->set('include_gmaps_js', $options['include_gmaps_js'])
         ;
     }
 


### PR DESCRIPTION
see https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Form/FormTypeInterface.php#L50

Declaration of Oh\GoogleMapFormTypeBundle\Form\Type\GoogleMapType::buildView() must be compatible with Symfony\Component\Form\FormTypeInterface::buildView
