### PR TITLE
Validator uses deprecated functions

### DIFF
--- a/Validator/Constraints/LatLngValidator.php
+++ b/Validator/Constraints/LatLngValidator.php
@@ -7,15 +7,15 @@ use Symfony\Component\Validator\ConstraintValidator;
 
 class LatLngValidator extends ConstraintValidator
 {
-    public function isValid($value, Constraint $constraint)
+    public function validate($value, Constraint $constraint)
     {
 		if (!preg_match('/^[0-9\-\.]+$/', $value['lat'], $matches) || !preg_match('/^[0-9\-\.]+$/', $value['lng'], $matches)) {
-			 $this->setMessage($constraint->message, array('%lat%' => (float)$value['lat'], '%lng%' => (float)$value['lng']));
+			 $this->context->addViolation($constraint->message, array('%lat%' => (float)$value['lat'], '%lng%' => (float)$value['lng']));
 			 return false;
 		}
 		if($value['lat'] > 90 || $value['lat'] < -90 || $value['lng'] > 180 || $value['lng'] < -180)
 		{
-			 $this->setMessage($constraint->message, array('%lat%' => (float)$value['lat'], '%lng%' => (float)$value['lng']));
+			 $this->context->addViolation($constraint->message, array('%lat%' => (float)$value['lat'], '%lng%' => (float)$value['lng']));
 			 return false;
 		}
 


### PR DESCRIPTION
Since Symfony 2.1 the function `isValid` of `ConstraintValidator` is deprecated. And in Symfony 2.3 it is removed completely. The same goes for `setMessage`.

This pull-request makes the validator Symfony 2.3 ready.
