### PR TITLE
Make google maps javascript protocol independent

### DIFF
--- a/Resources/views/Form/google_maps.html.twig
+++ b/Resources/views/Form/google_maps.html.twig
@@ -14,10 +14,10 @@
 	{% endblock %}
 	{% block oh_google_maps_javascripts %}
 		{% if include_jquery %}
-		<script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/1.7/jquery.min.js"></script>
+		<script type="text/javascript" src="//ajax.googleapis.com/ajax/libs/jquery/1.7/jquery.min.js"></script>
 		{% endif %}
 		{% if include_gmaps_js %}
-		<script type="text/javascript" src="http://maps.google.com/maps/api/js?sensor=true"></script>
+		<script type="text/javascript" src="//maps.google.com/maps/api/js?sensor=true"></script>
 		{% endif %}
 		{% javascripts
 			'@OhGoogleMapFormTypeBundle/Resources/public/js/jquery.ohgooglemaps.js'


### PR DESCRIPTION
This way it won't be blocked by browsers when the application is running on an https server
