### PR TITLE
optionally load javascripts using LcnIncludeAssetsBundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,9 @@ Screenshots
 Known problems
 -------
 
-Because the form type template includes javascript, there's not yet a way to bunch it all together at the very bottom of the page, so it is included at the bottom of the field. This means that jquery and the javascript plugin in Resources/public/js needs to be included before the field. I'm not sure of a way around this, but I think it's going to be addressed in a later version of the form framework.
+Because the form type template includes javascript, there's not yet a standard way to bunch it all together at the very bottom of the page, so it is included at the bottom of the field. This means that jquery and the javascript plugin in Resources/public/js needs to be included before the field.
+
+Alternatively, you can install [LcnIncludeAssetsBundle](https://github.com/FaiblUG/LcnIncludeAssetsBundle) and then all the required scripts should get loaded in the right place and order. 
 
 Credits
 -------

--- a/Resources/views/Form/google_maps.html.twig
+++ b/Resources/views/Form/google_maps.html.twig
@@ -1,4 +1,5 @@
 {% block oh_google_maps_widget %}
+{% set scriptLoaderAvailable = lcn_include_assets_available is defined and lcn_include_assets_available %}
 <div {{ block('widget_container_attributes') }}>
 	{% block oh_google_maps_html %} 
 	<div id="{{ id }}_container">
@@ -14,43 +15,43 @@
 	{% endblock %}
 	{% block oh_google_maps_javascripts %}
 		{% if include_jquery %}
-		<script type="text/javascript" src="//ajax.googleapis.com/ajax/libs/jquery/1.7/jquery.min.js"></script>
+			{% if scriptLoaderAvailable %}
+				{{ lcn_use_javascript('//ajax.googleapis.com/ajax/libs/jquery/1.7/jquery.min.js') }}
+			{% else %}
+				<script src="//ajax.googleapis.com/ajax/libs/jquery/1.7/jquery.min.js"></script>
+			{% endif %}
 		{% endif %}
 		{% if include_gmaps_js %}
-		<script type="text/javascript" src="//maps.google.com/maps/api/js?sensor=true"></script>
+			{% if scriptLoaderAvailable %}
+				{{ lcn_use_javascript('//maps.google.com/maps/api/js?sensor=true"') }}
+			{% else %}
+				<script src="//maps.google.com/maps/api/js?sensor=true"></script>
+			{% endif %}
 		{% endif %}
 		{% javascripts
 			'@OhGoogleMapFormTypeBundle/Resources/public/js/jquery.ohgooglemaps.js'
 		%}
-		<script type="text/javascript" src="{{ asset_url }}"></script>
+			{% if scriptLoaderAvailable %}
+				{{ lcn_use_javascript(asset_url) }}
+			{% else %}
+				<script src="{{ asset_url }}"></script>
+			{% endif %}
+
 		{% endjavascripts %}
 	{% endblock %}
 	{% block oh_google_maps_javascript %}
 		{% block oh_google_maps_callback %}
-			<script type="text/javascript">
+			<script>
 				var oh_google_maps_callback = function(location, gmap){
 					// your callback function here
 				}
 			</script>	
 		{% endblock %}
-		<script type="text/javascript">
-
-			$(function(){
-				$('#{{ id }}_map_canvas').ohGoogleMapType({
-				  'search_input_el'    : $('#{{ id }}_input'),
-				  'search_action_el'   : $('#{{ id }}_search_button'),
-				  'search_error_el'    : $('#{{ id }}_error'),
-				  'current_position_el': $('#{{ id }}_current_position'),
-				  'default_lat'        : '{% if value is defined and value and attribute(value, lat_name) %}{{ attribute(value, lat_name) }}{% else %}{{ default_lat }}{% endif %}',
-				  'default_lng'        : '{% if value is defined and value and attribute(value, lng_name) %}{{ attribute(value, lng_name) }}{% else %}{{ default_lng }}{% endif %}',
-				  'default_zoom'       : {% if value is defined and value and value.lat and value.lng %}15{% else %}5{% endif %},
-				  'lat_field'          : $('#{{ attribute(form, lat_name).vars.id }}'),
-				  'lng_field'          : $('#{{ attribute(form, lng_name).vars.id }}'),
-				  'callback'           : oh_google_maps_callback
-				});
-			});
-
-		</script>
+		{% if scriptLoaderAvailable %}
+			{{ lcn_use_inline_javascript(include("OhGoogleMapFormTypeBundle:Form:inline_script.html.twig")) }}
+		{% else %}
+			<script>{% include "OhGoogleMapFormTypeBundle:Form:inline_script.html.twig" %}</script>
+		{% endif %}
 	{% endblock %}
 </div>
 {% endblock %}

--- a/Resources/views/Form/inline_script.html.twig
+++ b/Resources/views/Form/inline_script.html.twig
@@ -1,0 +1,14 @@
+$(function(){
+    $('#{{ id }}_map_canvas').ohGoogleMapType({
+        'search_input_el'    : $('#{{ id }}_input'),
+        'search_action_el'   : $('#{{ id }}_search_button'),
+        'search_error_el'    : $('#{{ id }}_error'),
+        'current_position_el': $('#{{ id }}_current_position'),
+        'default_lat'        : '{% if value is defined and value and attribute(value, lat_name) %}{{ attribute(value, lat_name) }}{% else %}{{ default_lat }}{% endif %}',
+        'default_lng'        : '{% if value is defined and value and attribute(value, lng_name) %}{{ attribute(value, lng_name) }}{% else %}{{ default_lng }}{% endif %}',
+        'default_zoom'       : {% if value is defined and value and value.lat and value.lng %}15{% else %}5{% endif %},
+        'lat_field'          : $('#{{ attribute(form, lat_name).vars.id }}'),
+        'lng_field'          : $('#{{ attribute(form, lng_name).vars.id }}'),
+        'callback'           : oh_google_maps_callback
+    });
+});


### PR DESCRIPTION
Hi @ollietb, 

thank your for providing this useful plugin.

From your Readme:
>Because the form type template includes javascript, there's not yet a way to bunch it all together at the very bottom of the page, so it is included at the bottom of the field. This means that jquery and the javascript plugin in Resources/public/js needs to be included before the field. I'm not sure of a way around this, but I think it's going to be addressed in a later version of the form framework.

To overcome this limitation in Symfony 2 we at Faibl [Locaine.com](https://www.locaine.com) built the [LcnIncludeAssetsBundle](https://github.com/FaiblUG/LcnIncludeAssetsBundle). I created this small pull request to optionally enable automatic script loading in projects using the LcnIncludeAssets bundle.

If you like it, feel free to include the changes in your plugin.


Cheers!

Jonas