### PR TITLE
To remove warning javascript to use Google Maps API.

### DIFF
--- a/Resources/views/Form/google_maps.html.twig
+++ b/Resources/views/Form/google_maps.html.twig
@@ -17,7 +17,7 @@
 		<script type="text/javascript" src="//ajax.googleapis.com/ajax/libs/jquery/1.7/jquery.min.js"></script>
 		{% endif %}
 		{% if include_gmaps_js %}
-		<script type="text/javascript" src="//maps.google.com/maps/api/js?sensor=true"></script>
+		<script type="text/javascript" src="//maps.google.com/maps/api/js"></script>
 		{% endif %}
 		{% javascripts
 			'@OhGoogleMapFormTypeBundle/Resources/public/js/jquery.ohgooglemaps.js'


### PR DESCRIPTION
The warning is because the bundle used ?sensor=true on line 18 of /Resources/views/Form/google_maps.html.twig according to the [documentation](https://developers.google.com/maps/documentation/javascript/error-messages#deverrorcodes) is no longer needed,
